### PR TITLE
Added maps for dsau mails

### DIFF
--- a/config/sender_login_map
+++ b/config/sender_login_map
@@ -71,3 +71,18 @@ vc@taagekammeret.dk vc19@prodekanus.studorg.au.dk
 FU18@taagekammeret.dk fu18@prodekanus.studorg.au.dk
 FU@taagekammeret.dk fu19@prodekanus.studorg.au.dk
 EFUIT@taagekammeret.dk efuit19@prodekanus.studorg.au.dk
+
+dsau@dsau.dk strube@prodekanus.studorg.au.dk tversted@prodekanus.studorg.au.dk eriksen@prodekanus.studorg.au.dk funder@prodekanus.studorg.au.dk dohn@prodekanus.studorg.au.dk jeppe@prodekanus.studorg.au.dk magdalena@prodekanus.studorg.au.dk rysgaard@prodekanus.studorg.au.dk steffan@prodekanus.studorg.au.dk annaskov@prodekanus.studorg.au.dk annahallenberg@prodekanus.studorg.au.dk
+best@dsau.dk strube@prodekanus.studorg.au.dk tversted@prodekanus.studorg.au.dk eriksen@prodekanus.studorg.au.dk funder@prodekanus.studorg.au.dk dohn@prodekanus.studorg.au.dk jeppe@prodekanus.studorg.au.dk magdalena@prodekanus.studorg.au.dk rysgaard@prodekanus.studorg.au.dk steffan@prodekanus.studorg.au.dk annaskov@prodekanus.studorg.au.dk annahallenberg@prodekanus.studorg.au.dk
+
+Strube@dsau.dk strube@prodekanus.studorg.au.dk
+Tversted@dsau.dk tversted@prodekanus.studorg.au.dk
+Eriksen@dsau.dk eriksen@prodekanus.studorg.au.dk
+Funder@dsau.dk funder@prodekanus.studorg.au.dk
+Dohn@dsau.dk dohn@prodekanus.studorg.au.dk
+Jeppe@dsau.dk jeppe@prodekanus.studorg.au.dk
+Magdalena@dsau.dk magdalena@prodekanus.studorg.au.dk
+Rysgaard@dsau.dk rysgaard@prodekanus.studorg.au.dk
+Steffan@dsau.dk steffan@prodekanus.studorg.au.dk
+AnnaSkov@dsau.dk annaskov@prodekanus.studorg.au.dk
+AnnaHallenberg@dsau.dk annahallenberg@prodekanus.studorg.au.dk

--- a/config/sender_login_map
+++ b/config/sender_login_map
@@ -75,14 +75,14 @@ EFUIT@taagekammeret.dk efuit19@prodekanus.studorg.au.dk
 dsau@dsau.dk strube@prodekanus.studorg.au.dk tversted@prodekanus.studorg.au.dk eriksen@prodekanus.studorg.au.dk funder@prodekanus.studorg.au.dk dohn@prodekanus.studorg.au.dk jeppe@prodekanus.studorg.au.dk magdalena@prodekanus.studorg.au.dk rysgaard@prodekanus.studorg.au.dk steffan@prodekanus.studorg.au.dk annaskov@prodekanus.studorg.au.dk annahallenberg@prodekanus.studorg.au.dk
 best@dsau.dk strube@prodekanus.studorg.au.dk tversted@prodekanus.studorg.au.dk eriksen@prodekanus.studorg.au.dk funder@prodekanus.studorg.au.dk dohn@prodekanus.studorg.au.dk jeppe@prodekanus.studorg.au.dk magdalena@prodekanus.studorg.au.dk rysgaard@prodekanus.studorg.au.dk steffan@prodekanus.studorg.au.dk annaskov@prodekanus.studorg.au.dk annahallenberg@prodekanus.studorg.au.dk
 
-Strube@dsau.dk strube@prodekanus.studorg.au.dk
-Tversted@dsau.dk tversted@prodekanus.studorg.au.dk
-Eriksen@dsau.dk eriksen@prodekanus.studorg.au.dk
-Funder@dsau.dk funder@prodekanus.studorg.au.dk
-Dohn@dsau.dk dohn@prodekanus.studorg.au.dk
-Jeppe@dsau.dk jeppe@prodekanus.studorg.au.dk
-Magdalena@dsau.dk magdalena@prodekanus.studorg.au.dk
-Rysgaard@dsau.dk rysgaard@prodekanus.studorg.au.dk
-Steffan@dsau.dk steffan@prodekanus.studorg.au.dk
-AnnaSkov@dsau.dk annaskov@prodekanus.studorg.au.dk
-AnnaHallenberg@dsau.dk annahallenberg@prodekanus.studorg.au.dk
+strube@dsau.dk strube@prodekanus.studorg.au.dk
+tversted@dsau.dk tversted@prodekanus.studorg.au.dk
+eriksen@dsau.dk eriksen@prodekanus.studorg.au.dk
+funder@dsau.dk funder@prodekanus.studorg.au.dk
+dohn@dsau.dk dohn@prodekanus.studorg.au.dk
+jeppe@dsau.dk jeppe@prodekanus.studorg.au.dk
+magdalena@dsau.dk magdalena@prodekanus.studorg.au.dk
+rysgaard@dsau.dk rysgaard@prodekanus.studorg.au.dk
+steffan@dsau.dk steffan@prodekanus.studorg.au.dk
+annaskov@dsau.dk annaskov@prodekanus.studorg.au.dk
+hallenberg@dsau.dk hallenberg@prodekanus.studorg.au.dk


### PR DESCRIPTION
We added accounts for dsau members and alias for both dsau@dsau.dk and best@dsau.dk. I don't know if there is a smarter way to have 2 aliases for the same group of mails.